### PR TITLE
Add PGHero to the demo app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'nokogiri'
 gem 'pg', platforms: [:mri, :mingw, :x64_mingw]
 gem 'rack', '~> 2.2'
 gem 'rails'
+gem "sprockets-rails"
+# PGHero for the demo app
+gem 'pghero'
 
 platforms :ruby do
   gem "bootsnap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pghero (3.4.1)
+      activerecord (>= 6)
     prettier_print (1.2.1)
     prism (0.24.0)
     protocol-hpack (1.4.2)
@@ -452,6 +454,13 @@ GEM
       thor (>= 0.19.2)
     spoon (0.0.6)
       ffi
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
     stackprof (0.2.25)
     stringio (3.1.0)
     syntax_tree (6.2.0)
@@ -528,6 +537,7 @@ DEPENDENCIES
   net-smtp
   nokogiri
   pg
+  pghero
   pry-byebug
   pry-rails
   puma
@@ -545,6 +555,7 @@ DEPENDENCIES
   sorbet
   sorbet-runtime
   spoom
+  sprockets-rails
   stackprof
   tapioca
   timecop

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   mount GoodJob::Engine => "/good_job"
 
   get :create_job, to: 'application#create_job'
+
+  mount PgHero::Engine, at: "pghero"
 end


### PR DESCRIPTION
We want to show any helpful performance data in the GoodJob demo app so
we are installing PGHero:

https://github.com/ankane/pghero

We have to add Sprockets to the Rails app so the PGHero assets get loaded
correctly, whilst we could have used a more modern asset pipeline,
Sprockets is well supported and a simple drop in to get PGHero running.

PGHero is available at `/pghero`.

We have not enabled:

- [Suggested indexes](https://github.com/ankane/pghero/blob/master/guides/Rails.md#suggested-indexes)
- [Historical query stats](https://github.com/ankane/pghero/blob/master/guides/Rails.md#query-stats)
- [Historical space stats](https://github.com/ankane/pghero/blob/master/guides/Rails.md#historical-space-stats)

As these may not be suitable for the demo application and can always be
added later.
